### PR TITLE
Added unique identifier to cache_key in utils.py

### DIFF
--- a/django_user_agents/utils.py
+++ b/django_user_agents/utils.py
@@ -7,7 +7,7 @@ from user_agents import parse
 
 def get_cache_key(ua_string):
     # Some user agent strings are longer than 250 characters so we use its MD5
-    return md5(ua_string).hexdigest()
+    return ''.join(['django_user_agents.', md5(ua_string).hexdigest()])
 
 
 def get_user_agent(request):


### PR DESCRIPTION
Selwin,

Love django_user_agents.  It just saved me a ton of time and effort.  Great usability.

I was just debugging my cache and had a heck of a time figuring out what this one entry was that didn't have a unique identifier. It turned out to be django-user_agents. I was only able to figure this out by searching for the hash itself and found out that it was a user_agent string. That's what tipped me off.  Any how...

The django best practice appears to be appending a unique string to the cache_key for identification purposes. I prepended 'django_user_agents.' to the md5 you were using.

Fast, and easy :)

Happy coding,

T
