### PR TITLE
Fixed: crash when request has no META attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,10 @@ Running Tests
 Changelog
 =========
 
+0.3.1
+-----
+* Fixed a bug when request have no META attribute
+
 0.3.0
 -----
 * Python 3, thanks to @hwkns!

--- a/django_user_agents/__init__.py
+++ b/django_user_agents/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (0, 3, 0)
+VERSION = (0, 3, 1)

--- a/django_user_agents/utils.py
+++ b/django_user_agents/utils.py
@@ -23,6 +23,9 @@ def get_cache_key(ua_string):
 def get_user_agent(request):
     # Tries to get UserAgent objects from cache before constructing a UserAgent
     # from scratch because parsing regexes.yaml/json (ua-parser) is slow
+    if not request.META:
+        return None
+
     ua_string = request.META.get('HTTP_USER_AGENT', '')
     key = get_cache_key(ua_string)
     user_agent = cache.get(key)

--- a/django_user_agents/utils.py
+++ b/django_user_agents/utils.py
@@ -23,7 +23,7 @@ def get_cache_key(ua_string):
 def get_user_agent(request):
     # Tries to get UserAgent objects from cache before constructing a UserAgent
     # from scratch because parsing regexes.yaml/json (ua-parser) is slow
-    if not request.META:
+    if not hasattr(request, 'META'):
         return None
 
     ua_string = request.META.get('HTTP_USER_AGENT', '')

--- a/django_user_agents/utils.py
+++ b/django_user_agents/utils.py
@@ -24,7 +24,7 @@ def get_user_agent(request):
     # Tries to get UserAgent objects from cache before constructing a UserAgent
     # from scratch because parsing regexes.yaml/json (ua-parser) is slow
     if not hasattr(request, 'META'):
-        return None
+        return ''
 
     ua_string = request.META.get('HTTP_USER_AGENT', '')
     key = get_cache_key(ua_string)
@@ -40,6 +40,9 @@ def get_and_set_user_agent(request):
     # call get_user_agent and attach it to request so it can be reused
     if hasattr(request, 'user_agent'):
         return request.user_agent
+
+    if not request:
+        return parse('')
 
     request.user_agent = get_user_agent(request)
     return request.user_agent

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ description = ("A django package that allows easy identification of visitors' "
 
 setup(
     name='django-user_agents',
-    version='0.3.0',
+    version='0.3.1',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['django_user_agents'],


### PR DESCRIPTION
I'm having crash using template tag `user_agents`, because when I'm compressing my JavaScript & CSS files on deploy (using `django-compressor`) the request doesn't have the META attribute.

**Log**

```shell
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/core/management/base.py", line 533, in handle
    return self.handle_noargs(**options)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 274, in handle_noargs
    self.compress(sys.stdout, **options)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/compressor/management/commands/compress.py", line 221, in compress
    rendered = parser.render_nodelist(template, context, node)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/compressor/offline/django.py", line 114, in render_nodelist
    return node.nodelist.render(context)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/template/base.py", line 844, in render
    bit = self.render_node(node, context)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/template/base.py", line 858, in render_node
    return node.render(context)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 305, in render
    match = condition.eval(context)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/template/defaulttags.py", line 898, in eval
    return self.value.resolve(context, ignore_failures=True)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django/template/base.py", line 624, in resolve
    new_obj = func(obj, *arg_vals)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django_user_agents/templatetags/user_agents.py", line 21, in is_tablet
    return get_and_set_user_agent(request).is_tablet
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django_user_agents/utils.py", line 41, in get_and_set_user_agent
    request.user_agent = get_user_agent(request)
  File "/home/cm/envs/cm/local/lib/python2.7/site-packages/django_user_agents/utils.py", line 26, in get_user_agent
    ua_string = request.META.get('HTTP_USER_AGENT', '')
AttributeError: 'NoneType' object has no attribute 'META'
```