### PR TITLE
Use MiddlewareMixin in MIDDLEWARE Django 1.10 fix #13

### DIFF
--- a/django_user_agents/middleware.py
+++ b/django_user_agents/middleware.py
@@ -1,15 +1,10 @@
-import django
 from django.utils.functional import SimpleLazyObject
+from django.utils.deprecation import MiddlewareMixin
 
 from .utils import get_user_agent
 
-super_class = object
-if django.VERSION >= (1, 10):
-    from django.utils.deprecation import MiddlewareMixin
-    super_class = MiddlewareMixin
 
-
-class UserAgentMiddleware(super_class):
+class UserAgentMiddleware(MiddlewareMixin):
     # A middleware that adds a "user_agent" object to request
     def process_request(self, request):
         request.user_agent = SimpleLazyObject(lambda: get_user_agent(request))


### PR DESCRIPTION
MiddlewareMixin Class work for older and actual version of Django