### PR TITLE
Support for unicode character in user agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ cabal-dev
 *.pyc
 build/
 py/ua_parser.egg-info/
-
+*idea/

--- a/django_user_agents/tests/tests.py
+++ b/django_user_agents/tests/tests.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.test.client import Client, RequestFactory
@@ -93,3 +94,16 @@ class MiddlewareTest(SimpleTestCase):
         self.assertIsInstance(user_agent, UserAgent)
         self.assertIsNone(cache.get(get_cache_key(iphone_ua_string)))
         self.assertIsInstance(utils.cache.get(get_cache_key(iphone_ua_string)), UserAgent)
+
+
+unicode_ua_string = 'Mozilla/5.0 (Linux; Android 4.4.2; X325 – Locked to Life Wireless Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36'
+
+class UtilsTest(SimpleTestCase):
+
+    @override_settings(USER_AGENTS_CACHE=None)
+    def test_unicode_ua_string(self):
+        reload_module(utils)  # re-import with patched settings
+
+        request = RequestFactory(HTTP_USER_AGENT=unicode_ua_string).get('')
+        
+        self.assertTrue(user_agents.is_mobile(request))

--- a/django_user_agents/utils.py
+++ b/django_user_agents/utils.py
@@ -45,6 +45,10 @@ def get_user_agent(request):
         return ''
 
     ua_string = request.META.get('HTTP_USER_AGENT', '')
+
+    if not isinstance(ua_string, text_type):
+        ua_string = ua_string.decode('utf-8')
+
     if cache:
         key = get_cache_key(ua_string)
         user_agent = cache.get(key)

--- a/django_user_agents/utils.py
+++ b/django_user_agents/utils.py
@@ -47,7 +47,7 @@ def get_user_agent(request):
     ua_string = request.META.get('HTTP_USER_AGENT', '')
 
     if not isinstance(ua_string, text_type):
-        ua_string = ua_string.decode('utf-8')
+        ua_string = ua_string.decode('utf-8', 'ignore')
 
     if cache:
         key = get_cache_key(ua_string)


### PR DESCRIPTION
Ran into an issue where a en-dash character exists in a user agent string would cause an error:
```
======================================================================
ERROR: test_unicode_ua_string (django_user_agents.tests.tests.UtilsTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/test/utils.py", line 384, in inner
    return func(*args, **kwargs)
  File "/ua/django_user_agents/tests/tests.py", line 107, in test_unicode_ua_string
    self.assertTrue(user_agents.is_mobile(request))
  File "/ua/django_user_agents/templatetags/user_agents.py", line 11, in is_mobile
    return get_and_set_user_agent(request).is_mobile
  File "/ua/django_user_agents/utils.py", line 71, in get_and_set_user_agent
    request.user_agent = get_user_agent(request)
  File "/ua/django_user_agents/utils.py", line 58, in get_user_agent
    user_agent = parse(ua_string)
  File "/usr/local/lib/python2.7/site-packages/user_agents/parsers.py", line 254, in parse
    return UserAgent(user_agent_string)
  File "/usr/local/lib/python2.7/site-packages/user_agents/parsers.py", line 135, in __init__
    ua_dict = user_agent_parser.Parse(user_agent_string)
  File "/usr/local/lib/python2.7/site-packages/ua_parser/user_agent_parser.py", line 227, in Parse
    'device': ParseDevice(user_agent_string, **jsParseBits),
  File "/usr/local/lib/python2.7/site-packages/ua_parser/user_agent_parser.py", line 310, in ParseDevice
    device, brand, model = deviceParser.Parse(user_agent_string)
  File "/usr/local/lib/python2.7/site-packages/ua_parser/user_agent_parser.py", line 198, in Parse
    model = self.MultiReplace(self.model_replacement, match)
  File "/usr/local/lib/python2.7/site-packages/ua_parser/user_agent_parser.py", line 179, in MultiReplace
    _string = re.sub(r'\$(\d)', _repl, string)
  File "/usr/local/lib/python2.7/re.py", line 155, in sub
    return _compile(pattern, flags).sub(repl, string, count)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 5: ordinal not in range(128)
```